### PR TITLE
Rename documentation to English

### DIFF
--- a/.cursor-rules
+++ b/.cursor-rules
@@ -26,7 +26,7 @@ prefer_pure_functions = true
 prefer_immutable_dataclasses = true
 
 # CLI & API Consistency
-cli_prefix = "alexandrian"
+cli_prefix = "42"
 cli_commands_must_be = ["single verb", "lowercase", "idempotent"]
 api_prefix = "/"
 match_prd_endpoints = true
@@ -41,7 +41,7 @@ test_style = "pytest"
 use_fixture_autodiscovery = true
 
 # Config & Constants
-use_config_keys_from = "alexandrian.config.json"
+use_config_keys_from = "42.config.json"
 no_hardcoded_constants = true
 no_hardcoded_ports = true
 prefer_env_vars_for_secrets = true

--- a/MASTERPLAN.md
+++ b/MASTERPLAN.md
@@ -1,0 +1,48 @@
+# MASTERPLAN 42
+
+42 aims to evolve into a digital organism capable of reasoning and acting without constant human supervision. The design borrows from the human body: `42.un` handles sensors, a reflex layer uses Redis for fast reactions, and `42.deux` and `42.trois` serve as the analytic brain and reinforcement center. Memories accumulate in Alexandrian, a Qdrant-based vector store, while a conscience module filters every decision.
+
+The internal runtime orchestrates all components. Incoming events first hit the Redis bus. The main loop scores each task with a Bayesian filter and quantum solver, builds reasoning chains via knowledge graphs, and executes them through action agents. Meanwhile `42.trois` continually trains a reinforcement loop that compresses embeddings via HDBSCAN. This self-learning loop refines priorities and prunes outdated memories.
+
+In parallel, the system follows a plugin-first philosophy: every module wraps a trusted library and exposes a small interface. This keeps 42 lean and simplifies upgrades. Documentation and tests accompany each phase to ensure reliability and encourage contributions.
+
+## Phase zéro – Foundations
+
+This phase sets up the minimal CLI and API. Vectorization uses `sentence-transformers`, Qdrant is deployed, and the initial ingestion is implemented. Commands like `create`, `import`, `ask`, and `status` demonstrate an end-to-end flow.
+
+## Phase un – Reflex and ingestion
+
+Redis is introduced to relay events, and `42.un` constantly scans for new sources. Tasks are prioritized before execution, and a test suite ensures module stability.
+
+## Phase deux – Advanced optimization
+
+`42.deux` combines Bayesian optimization (BoTorch) with a quantum solver (PennyLane + CUDA-Q). Knowledge graphs (NetworkX or cuGraph) link data fragments. Semantic compression via HDBSCAN is strengthened under the Meta-Optimizer Layer, which automatically tunes hyperparameters.
+
+## Phase trois – Autonomous learning
+
+The `42.trois` module launches a reinforcement loop via RLlib or Stable Baselines3. It also generates synthetic data for rare scenarios. The Contextual Memory Pruner simultaneously trims low-value embeddings, keeping the system agile and relevant.
+
+## Phase quatre – Multi-agent orchestration
+
+At this stage, 42 delegates tasks to multiple specialized agents. Memory expands through dynamic pruning, while an orchestrator balances compute between exploration and exploitation. Conscience and Soul modules ensure actions remain aligned with defined values.
+
+## Core Modules
+
+- **Steve** – discovers and ingests new data sources.
+- **Teleporter** – moves and transforms information between modules.
+- **Request & Missions** – store short and long-term objectives.
+- **Conscience & Soul** – moral filters and overall intent.
+- **Alexandrian Memory** – compressed vectors and semantic graph.
+- **Optimization Stack** – Bayesian filter, quantum solver, graphs, reinforcement.
+- **Autonomic Loop** – full perception → scoring → execution → learning cycle.
+- **Self-Tuning Embeddings** – Classical (Mistral/LoRA) → Quantum (PennyLane + CUDA-Q) → Alexandrian Memory → RL Feedback → Self-tuning loop using PEFT, Triplet Learning, and RLHF for continuous refinement that drives smarter quantum reasoning and symbolic alignment.
+
+## Three 10x Accelerators
+
+1. **Meta-Optimizer Layer** – supervises modules and retunes hyperparameters automatically.
+2. **Synthetic Data Generator** – creates hypothetical scenarios to speed up learning.
+3. **Contextual Memory Pruner** – continuously removes stale embeddings to keep knowledge fresh.
+
+## Beyond 42.quatre
+
+Future versions (42.cinq and beyond) will expand multi-agent orchestration and add a global planner. The goal is to integrate multiple local models, energize online learning, and enable complex missions without direct human intervention.

--- a/README.md
+++ b/README.md
@@ -1,71 +1,40 @@
-# Alexandrian
+# 42
 
-Alexandrian is a zero-cloud, open-source Retrieval Augmented Generation (RAG) framework for local codebases and documents. It embeds, clusters and searches your files entirely offline, powering local Q&A via an Ollama-hosted LLM. Alexandrian exposes both a CLI and FastAPI backend so you can ingest repositories, query them, and build automations without any external services.
+42 is an autonomous, self-learning AI system.
+It ingests, compresses, and exploits knowledge to reason and act.
+The goal is a local loop of perception, memory, and morally aligned execution.
 
-## Installation
-
-Alexandrian installs everything it needs, including Docker images and Ollama models.
-
-```bash
-# bootstrap a project
-npx alexandrian create
+```
+Sensory -> Reflex -> Brain -> Memory -> Muscles -> Soul
+    |        |        |       |         |        |
+42.un    Queue    42.deux  DB    Actions   Conscience
 ```
 
-This command installs Docker and Ollama if missing, pulls the default `mistral` and `bge-small-en` models, and generates `alexandrian.config.json` with sensible defaults.
+### Self-Tuning Embeddings Subsystem
 
-### Requirements
+Classical (Mistral/LoRA) → Quantum (PennyLane + CUDA-Q) → Alexandrian Memory → RL Feedback → Self-tuning loop.
+Uses PEFT, Triplet Learning, and RLHF for continuous fine-tuning. Embedding refinement drives smarter quantum reasoning and symbolic alignment.
 
-- Docker
-- Node.js (for `npx`)
-- Python 3.11+
+## Version Roadmap
 
-After running `create`, activate your environment and install Python dependencies:
+- **42.zéro** – baseline CLI/API with vector memory
+- **42.un** – reflex loop via Redis and automated ingestion
+- **42.deux** – Bayesian optimization and knowledge graphs
+- **42.trois** – autonomous reinforcement and continuous learning
+- **42.quatre** – multi-agent orchestration and contextual pruning
+
+## Quick Start
+
+Install the core dependencies (Redis, Qdrant, HDBSCAN, BoTorch, PennyLane, CUDA-Q, RLlib) and then:
 
 ```bash
 pip install -r requirements.txt
+42          # prints a welcome message with setup tips
+42 start    # launches the API and vector store
+42 up       # alternative foreground start
+42 e=mc^2   # example one-liner
+42 import ./src
+42 ask "How does the server start?"
 ```
 
-## Quickstart
-
-```bash
-# index your source folder
-alexandrian import ./src
-
-# ask a question
-alexandrian ask "How do we start the server?"
-```
-
-Other commands include `recluster`, `embed --text "..."`, `purge`, and `status`.
-
-## Development Workflow
-
-To keep the code base consistent run these commands before committing:
-
-```bash
-# format and lint
-ruff .
-black .
-
-# run the tests
-pytest -q
-```
-
-Type hints are required for all new functions. Include docstrings that explain
-arguments and return values so team members and code generation tools can easily
-understand the purpose of each module.
-
-## Configuration
-
-`alexandrian.config.json` stores model paths, ports, embedding dimensions and clustering parameters. Edit this file to point to custom models or tweak HDBSCAN settings.
-
-## Extending
-
-Alexandrian is modular. Swap out the embedding model, plug in a different vector database, or build additional FastAPI routes. The CLI uses the same API endpoints so extensions automatically benefit from backend updates.
-
-## Screenshot
-
-![Placeholder screenshot](docs/screenshot.png)
-
-## License
-
-MIT
+See `TASKS.md` for the detailed development plan.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,9 +1,9 @@
 # Implementation Tasks
 
-This document expands the PRD into concrete development steps for each component. Follow these tasks sequentially when building Alexandrian.
+This document expands the PRD into concrete development steps for each component. Follow these tasks sequentially when building 42.
 
 ## System Overview
-Alexandrian consists of several cooperating modules, each built on a stable
+42 consists of several cooperating modules, each built on a stable
 open‑source library:
 
 1. **Embedding Engine** – turns text into numeric vectors using a local model.
@@ -33,7 +33,7 @@ Leverage these proven projects and pin their versions in `requirements.txt`:
 | CLI                | `typer`                                 | `0.12.3` |
 | API                | `fastapi`                               | `0.110.1` |
 
-Wrap each library behind an interface in `alexandrian` so the rest of the
+Wrap each library behind an interface in `42` so the rest of the
 codebase never calls these dependencies directly.
 
 Keep this picture in mind while you work; each task below maps back to one of these pieces.
@@ -49,12 +49,12 @@ New engineers should set up a Python 3.11 virtual environment and install the de
 Even small modules should have at least one test so we know they work as expected.
 
 ## Repository Setup
-1. Scaffold a Python package named `alexandrian` with submodules:
+1. Scaffold a Python package named `42` with submodules:
    `embedding.py`, `vector_store.py`, `cluster.py`, `prompt.py`, `llm.py`,
    `chunker.py`, `cli.py`, `api.py`, and `config.py`.
 2. Create `requirements.txt` enumerating all dependencies listed in the PRD with
    **pinned versions** so updates are predictable.
-3. Provide a starter `alexandrian.config.json` with default model names, ports
+3. Provide a starter `42.config.json` with default model names, ports
    and embedding dimensions.
 4. Define common data structures in `interfaces.py` to keep module APIs
    consistent.
@@ -65,7 +65,7 @@ Even small modules should have at least one test so we know they work as expecte
 - Wrap the library in `embedding.py` so callers use a stable API.
    `embedding.py`, `vector_store.py`, `cluster.py`, `prompt.py`, `llm.py`, `chunker.py`, `cli.py`, `api.py`, and `config.py`.
 2. Create `requirements.txt` enumerating all dependencies listed in the PRD (FastAPI, sentence-transformers, qdrant-client, hdbscan, etc.).
-3. Provide a starter `alexandrian.config.json` with default model names, ports and embedding dimensions.
+3. Provide a starter `42.config.json` with default model names, ports and embedding dimensions.
 4. Configure linting and formatters (`black` + `ruff`).
 
 ## Embedding Engine
@@ -74,17 +74,17 @@ Even small modules should have at least one test so we know they work as expecte
   - `embed_text(text: str) -> list[float]`
   - `embed_text_batch(texts: list[str]) -> list[list[float]]`
 - Add docstrings describing the expected input and output.
-- Expose a CLI command `alexandrian embed --text TEXT` that prints the vector as JSON.
+- Expose a CLI command `42 embed --text TEXT` that prints the vector as JSON.
 - Create tests in `tests/test_embedding.py` asserting that the returned vector has the correct dimension and datatype.
 
 ## Vector Store (Qdrant)
 - Supply a Docker Compose file that launches Qdrant.
-- During `alexandrian create`, start the container and wait for readiness.
+- During `42 create`, start the container and wait for readiness.
 - Wrap `qdrant-client` inside `vector_store.py` exposing
   `upsert`, `search`, `update_payload`, and `get_all_vectors` so callers never
   import the library directly.
 - Implement wrapper methods `upsert`, `search`, `update_payload`, and `get_all_vectors`.
-- Read connection info from `alexandrian.config.json`.
+- Read connection info from `42.config.json`.
 - Add tests using a temporary Qdrant instance to verify inserts and searches.
 - Document each method with type hints and explain what parameters mean.
 
@@ -94,7 +94,7 @@ Even small modules should have at least one test so we know they work as expecte
   `cluster.py` so future upgrades are isolated.
 - Build `recluster_vectors()` that loads all vectors, runs HDBSCAN and updates each payload with `cluster_id`.
 - Optionally generate a UMAP plot saved under `docs/cluster.png`.
-- Provide CLI command `alexandrian recluster` and FastAPI endpoint `/recluster`.
+- Provide CLI command `42 recluster` and FastAPI endpoint `/recluster`.
 - Include unit tests that feed a small set of vectors and assert clusters are returned.
 
 ## Prompt Builder
@@ -118,7 +118,7 @@ Even small modules should have at least one test so we know they work as expecte
 - Parse Python files with `ast` to split by function or class.
 - Split Markdown files by heading level.
 - Emit metadata: file path, start/end lines and cluster ID.
-- Implement `alexandrian import PATH` to ingest a folder recursively.
+- Implement `42 import PATH` to ingest a folder recursively.
 - Provide tests covering Python and Markdown splitting so future changes do not break chunk generation.
 
 ## CLI Interface
@@ -137,20 +137,20 @@ Even small modules should have at least one test so we know they work as expecte
 - Keep route handlers thin and delegate to the wrapper modules so API logic stays minimal.
 
 ## Config Layer
-- Generate `alexandrian.config.json` during `create` if missing.
+- Generate `42.config.json` during `create` if missing.
 - Provide a `load_config()` helper returning a typed dataclass.
 - Allow overriding values via environment variables.
 - Add tests that load a temporary config file and ensure values map to the dataclass correctly.
 - Record dependency versions in the config so upgrades can be audited.
 
 ## Installer
-- `npx alexandrian create` installs Docker and Ollama if absent, pulls the default models and Python dependencies, then launches Qdrant and the API server.
+- `npx 42 create` installs Docker and Ollama if absent, pulls the default models and Python dependencies, then launches Qdrant and the API server.
 - Print next steps after setup completes.
 - Provide installation logs so users can troubleshoot if something fails.
 - Verify that pinned versions from `requirements.txt` are installed.
 
 ## Postinstall Verification
-- Implement `alexandrian status` to check Qdrant and Ollama health, report model names, cluster count and total chunks.
+- Implement `42 status` to check Qdrant and Ollama health, report model names, cluster count and total chunks.
 - Run a small embedding and LLM request to confirm the full pipeline works.
 - Document common errors and where to look in the logs.
 - Ensure the command also reports the versions of all pinned dependencies.


### PR DESCRIPTION
## Summary
- translate the README and MASTERPLAN docs into English while keeping French version names
- describe self-tuning embeddings subsystem
- update quick start commands for simple usage
- set CLI prefix to `42` and update config file name in Cursor rules

## Testing
- `black . --check`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888fc7b33ac8333beecb248f4f4fd6a